### PR TITLE
chore: optimize dependabot and CI/CD workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     versioning-strategy: increase
+    reviewers:
+      - "drzioner"
+    commit-message:
+      prefix: "chore(deps)"
     labels:
       - "dependencies"
     groups:
@@ -39,6 +43,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    reviewers:
+      - "drzioner"
+    commit-message:
+      prefix: "chore(deps)"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
 
 permissions:
   contents: read
@@ -34,7 +40,12 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node-version }}
-      - run: pnpm test:coverage
+      - name: Run tests with coverage
+        if: matrix.node-version == 24
+        run: pnpm test:coverage
+      - name: Run tests
+        if: matrix.node-version != 24
+        run: pnpm test
       - name: Upload coverage
         if: matrix.node-version == 24
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: pnpm validate
 
-      - name: Ensure npm >= 11.5.1 for trusted publishing
-        run: npm install -g npm@latest
-
       - name: Create Release PR
         id: changesets
         uses: changesets/action@v1
@@ -36,6 +33,10 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure npm >= 11.5.1 for trusted publishing
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: npm install -g npm@latest
 
       - name: Publish to npm
         if: steps.changesets.outputs.hasChangesets == 'false'


### PR DESCRIPTION
## Summary

Optimizations that were planned for PR #16 but didn't make it before merge.

### Dependabot
- Add `commit-message` prefix (`chore(deps)`) for cleaner git history
- Add `reviewers` (`drzioner`) for auto-assignment on dependency PRs

### CI (`ci.yml`)
- Skip CI for docs-only changes (`*.md`, `docs/**`) — saves CI minutes
- Run `pnpm test:coverage` only on Node 24; plain `pnpm test` on Node 20/22 — saves ~30s per run

### Release (`release.yml`)
- Move `npm install -g npm@latest` inside the publish conditional — skips when no packages to publish

## Verification

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] 516 tests pass